### PR TITLE
travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
       name: "pimba/librespot docker image build & publication"
       script:
       - |
-        travis_wait 20 buildctl build --frontend=dockerfile.v0 \
+        buildctl build --frontend=dockerfile.v0 \
             --opt platform=linux/armhf \
             --opt filename=./Dockerfile \
             --local dockerfile=./librespot \
@@ -38,7 +38,7 @@ jobs:
       name: "pimba/shairport docker image build & publication"
       script:
       - |
-        travis_wait 20 buildctl build --frontend=dockerfile.v0 \
+        buildctl build --frontend=dockerfile.v0 \
             --opt platform=linux/armhf \
             --opt filename=./Dockerfile \
             --local dockerfile=./shairport \
@@ -54,7 +54,7 @@ jobs:
       name: "pimba/mopidy docker image build & publication"
       script:
       - |
-        travis_wait 20 buildctl build --frontend=dockerfile.v0 \
+        buildctl build --frontend=dockerfile.v0 \
             --opt platform=linux/armhf \
             --opt filename=./Dockerfile \
             --local dockerfile=./mopidy \

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
             --local dockerfile=./librespot \
             --local context=./librespot \
             --output type=image,name=docker.io/pimba/librespot
-        docker images
+      - docker images
     -
       name: "pimba/shairport docker image build"
       script:
@@ -33,7 +33,7 @@ jobs:
             --local dockerfile=./shairport \
             --local context=./shairport \
             --output type=image,name=docker.io/pimba/shairport
-        docker images
+      - docker images
     -
       name: "pimba/mopidy docker image build"
       script:
@@ -44,4 +44,4 @@ jobs:
             --local dockerfile=./mopidy \
             --local context=./mopidy \
             --output type=image,name=docker.io/pimba/mopidy
-        docker images
+      - docker images

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
             --opt filename=./Dockerfile \
             --local dockerfile=./librespot \
             --local context=./librespot \
-            --output type=image,name=docker.io/pimba/librespot
+            --output type=docker,name=docker.io/pimba/librespot | docker load
       - docker images
     -
       name: "pimba/shairport docker image build"
@@ -32,7 +32,7 @@ jobs:
             --opt filename=./Dockerfile \
             --local dockerfile=./shairport \
             --local context=./shairport \
-            --output type=image,name=docker.io/pimba/shairport
+            --output type=docker,name=docker.io/pimba/shairport | docker load
       - docker images
     -
       name: "pimba/mopidy docker image build"
@@ -43,5 +43,5 @@ jobs:
             --opt filename=./Dockerfile \
             --local dockerfile=./mopidy \
             --local context=./mopidy \
-            --output type=image,name=docker.io/pimba/mopidy
+            --output type=docker,name=docker.io/pimba/mopidy | docker load
       - docker images

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,10 @@ before_install:
 - export BUILDKIT_HOST=tcp://0.0.0.0:1234
 
 before_script:
-- echo -e "commit: $TRAVIS_COMMIT\ntag: $TRAVIS_TAG\nbranch: $TRAVIS_BRANCH\nbuild: $TRAVIS_BUILD_NUMBER"
+- "echo commit: $TRAVIS_COMMIT"
+- "echo tag: $TRAVIS_TAG"
+- "echo branch: $TRAVIS_BRANCH"
+- "echo build: $TRAVIS_BUILD_NUMBER"
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,47 +1,65 @@
 dist: xenial
 language: minimal
 
+services:
+- docker
+
 before_install:
 - sudo docker run --privileged linuxkit/binfmt:v0.6
 - sudo docker run -d --privileged -p 1234:1234 --name buildkit moby/buildkit:latest --addr tcp://0.0.0.0:1234 --oci-worker-platform linux/armhf
 - sudo docker cp buildkit:/usr/bin/buildctl /usr/bin/
 - export BUILDKIT_HOST=tcp://0.0.0.0:1234
 
-services:
-- docker
+before_script:
+- echo -e "commit: $TRAVIS_COMMIT\ntag: $TRAVIS_TAG\nbranch: $TRAVIS_BRANCH\nbuild: $TRAVIS_BUILD_NUMBER"
 
 jobs:
   include:
-    - stage: build
-      name: "pimba/librespot docker image build"
+    - stage: docker
+      name: "pimba/librespot docker image build & publication"
       script:
       - |
-        buildctl build --frontend=dockerfile.v0 \
+        travis_wait 20 buildctl build --frontend=dockerfile.v0 \
             --opt platform=linux/armhf \
             --opt filename=./Dockerfile \
             --local dockerfile=./librespot \
             --local context=./librespot \
             --output type=docker,name=docker.io/pimba/librespot | docker load
       - docker images
+      - |
+        if [ "$TRAVIS_BRANCH" = master ]; then
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          docker push docker.io/pimba/librespot
+        fi
     -
-      name: "pimba/shairport docker image build"
+      name: "pimba/shairport docker image build & publication"
       script:
       - |
-        buildctl build --frontend=dockerfile.v0 \
+        travis_wait 20 buildctl build --frontend=dockerfile.v0 \
             --opt platform=linux/armhf \
             --opt filename=./Dockerfile \
             --local dockerfile=./shairport \
             --local context=./shairport \
             --output type=docker,name=docker.io/pimba/shairport | docker load
       - docker images
+      - |
+        if [ "$TRAVIS_BRANCH" = master ]; then
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          docker push docker.io/pimba/shairport
+        fi
     -
-      name: "pimba/mopidy docker image build"
+      name: "pimba/mopidy docker image build & publication"
       script:
       - |
-        buildctl build --frontend=dockerfile.v0 \
+        travis_wait 20 buildctl build --frontend=dockerfile.v0 \
             --opt platform=linux/armhf \
             --opt filename=./Dockerfile \
             --local dockerfile=./mopidy \
             --local context=./mopidy \
             --output type=docker,name=docker.io/pimba/mopidy | docker load
       - docker images
+      - |
+        if [ "$TRAVIS_BRANCH" = master ]; then
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          docker push docker.io/pimba/mopidy
+        fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+dist: xenial
+language: minimal
+
+before_install:
+- sudo docker run --privileged linuxkit/binfmt:v0.6
+- sudo docker run -d --privileged -p 1234:1234 --name buildkit moby/buildkit:latest --addr tcp://0.0.0.0:1234 --oci-worker-platform linux/armhf
+- sudo docker cp buildkit:/usr/bin/buildctl /usr/bin/
+- export BUILDKIT_HOST=tcp://0.0.0.0:1234
+
+services:
+- docker
+
+jobs:
+  include:
+    - stage: build
+      name: "pimba/librespot docker image build"
+      script:
+      - |
+        buildctl build --frontend=dockerfile.v0 \
+            --opt platform=linux/armhf \
+            --opt filename=./Dockerfile \
+            --local dockerfile=./librespot \
+            --local context=./librespot \
+            --output type=image,name=docker.io/pimba/librespot
+        docker images
+    -
+      name: "pimba/shairport docker image build"
+      script:
+      - |
+        buildctl build --frontend=dockerfile.v0 \
+            --opt platform=linux/armhf \
+            --opt filename=./Dockerfile \
+            --local dockerfile=./shairport \
+            --local context=./shairport \
+            --output type=image,name=docker.io/pimba/shairport
+        docker images
+    -
+      name: "pimba/mopidy docker image build"
+      script:
+      - |
+        buildctl build --frontend=dockerfile.v0 \
+            --opt platform=linux/armhf \
+            --opt filename=./Dockerfile \
+            --local dockerfile=./mopidy \
+            --local context=./mopidy \
+            --output type=image,name=docker.io/pimba/mopidy
+        docker images

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ jobs:
       name: "pimba/librespot docker image build & publication"
       script:
       - |
+        while sleep 9m; do
+          echo "====[ $SECONDS seconds still running ]===="
+        done &
         buildctl build --frontend=dockerfile.v0 \
             --opt platform=linux/armhf \
             --opt filename=./Dockerfile \
@@ -54,6 +57,9 @@ jobs:
       name: "pimba/mopidy docker image build & publication"
       script:
       - |
+        while sleep 9m; do
+          echo "====[ $SECONDS seconds still running ]===="
+        done &
         buildctl build --frontend=dockerfile.v0 \
             --opt platform=linux/armhf \
             --opt filename=./Dockerfile \


### PR DESCRIPTION
- Add Travis CI build of docker containers and push them to the docker hub if on the master branch
- Use a hack to work around job timeouts because there is no output for 10mn but travis_wait messes with the docker load (trick from http://junaruga.hatenablog.com/entry/2019/02/25/045137)