### PR TITLE
[travis] Fix librespot compilation, Add packer step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,8 @@ jobs:
       name: "enlarge raspbian disk image and activate ssh"
       script:
       - mv ~/qemu/bin/qemu-arm ~/qemu/bin/qemu-arm-static
+      - ls -l ~/qemu/bin/
+      - ls -l /home/travis/qemu/bin/qemu-arm-static
       - wget https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-04-09/2019-04-08-raspbian-stretch-lite.zip
       - sudo env "PATH=$PATH" ~/packer/bin/packer build packer.json
       - ls -lh pimba.img

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,22 @@
 dist: xenial
-language: minimal
+language: go
+
+go:
+- 1.11.x
 
 services:
 - docker
+
+cache:
+  directories:
+    - $HOME/qemu
+    - $HOME/packer
+
+addons:
+  apt:
+    update: true
+    packages:
+    - kpartx
 
 before_install:
 - sudo docker run --privileged linuxkit/binfmt:v0.6
@@ -15,6 +29,9 @@ before_script:
 - "echo tag: $TRAVIS_TAG"
 - "echo branch: $TRAVIS_BRANCH"
 - "echo build: $TRAVIS_BUILD_NUMBER"
+- bash bin/travis-qemu.sh
+- bash bin/travis-packer.sh
+- export PATH=$PATH:$HOME/qemu/bin:$HOME/packer/bin/
 
 jobs:
   include:
@@ -72,3 +89,8 @@ jobs:
           echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
           docker push docker.io/pimba/mopidy
         fi
+    - stage: packer
+      name: "enlarge raspbian disk image and activate ssh"
+      script:
+      - sudo packer build packer.json
+      - ls -lh pimba.img

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,5 +92,6 @@ jobs:
     - stage: packer
       name: "enlarge raspbian disk image and activate ssh"
       script:
+      - ls -l $HOME/packer/bin
       - sudo packer build packer.json
       - ls -lh pimba.img

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,25 +35,25 @@ before_script:
 jobs:
   include:
     - stage: docker
-#      name: "pimba/librespot docker image build & publication"
-#      script:
-#      - |
-#        while sleep 9m; do
-#          echo "====[ $SECONDS seconds still running ]===="
-#        done &
-#        buildctl build --frontend=dockerfile.v0 \
-#            --opt platform=linux/armhf \
-#            --opt filename=./Dockerfile \
-#            --local dockerfile=./librespot \
-#            --local context=./librespot \
-#            --output type=docker,name=docker.io/pimba/librespot | docker load
-#      - docker images
-#      - |
-#        if [ "$TRAVIS_BRANCH" = master ]; then
-#          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-#          docker push docker.io/pimba/librespot
-#        fi
-#    -
+      name: "pimba/librespot docker image build & publication"
+      script:
+      - |
+        while sleep 9m; do
+          echo "====[ $SECONDS seconds still running ]===="
+        done &
+        buildctl build --frontend=dockerfile.v0 \
+          --opt platform=linux/armhf \
+          --opt filename=./Dockerfile \
+          --local dockerfile=./librespot \
+          --local context=./librespot \
+          --output type=docker,name=docker.io/pimba/librespot | docker load
+      - docker images
+      - |
+        if [ "$TRAVIS_BRANCH" = master ]; then
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          docker push docker.io/pimba/librespot
+        fi
+    -
       name: "pimba/shairport docker image build & publication"
       script:
       - |
@@ -95,3 +95,12 @@ jobs:
       - wget -nv https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-04-09/2019-04-08-raspbian-stretch-lite.zip
       - sudo ~/packer/bin/packer build packer.json
       - ls -lh pimba.img
+      - |
+        sudo ~/qemu/bin/qemu-system-arm \
+          -M versatilepb -cpu arm1176 -m 256 \
+          -hda ./pimba.img \
+          -net nic -net user,hostfwd=tcp::2222-:22 \
+          -dtb ~/qemu/rpi-kernel/versatile-pb.dtb \
+          -kernel ~/qemu/rpi-kernel/kernel-qemu-4.14.79-stretch \
+          -append 'root=/dev/sda2 panic=1' \
+          -no-reboot

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,5 +92,6 @@ jobs:
     - stage: packer
       name: "enlarge raspbian disk image and activate ssh"
       script:
+      - sudo env "PATH=$PATH" which packer
       - sudo env "PATH=$PATH" packer build packer.json
       - ls -lh pimba.img

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,12 +41,7 @@ jobs:
         while sleep 9m; do
           echo "====[ $SECONDS seconds still running ]===="
         done &
-        buildctl build --frontend=dockerfile.v0 \
-          --opt platform=linux/armhf \
-          --opt filename=./Dockerfile \
-          --local dockerfile=./librespot \
-          --local context=./librespot \
-          --output type=docker,name=docker.io/pimba/librespot | docker load
+        cd librespot && make build
       - docker images
       - |
         if [ "$TRAVIS_BRANCH" = master ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,7 @@ jobs:
     - stage: packer
       name: "enlarge raspbian disk image and activate ssh"
       script:
+      - ln -s ~/qemu/bin/qemu-arm ~/qemu/bin/qemu-arm-static
       - sudo env "PATH=$PATH" echo $PATH
       - sudo env "PATH=$PATH" ~/packer/bin/packer build packer.json
       - ls -lh pimba.img

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,5 @@ jobs:
     - stage: packer
       name: "enlarge raspbian disk image and activate ssh"
       script:
-      - ls -l $HOME/packer/bin
-      - sudo packer build packer.json
+      - sudo env "PATH=$PATH" packer build packer.json
       - ls -lh pimba.img

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,9 +92,7 @@ jobs:
     - stage: packer
       name: "enlarge raspbian disk image and activate ssh"
       script:
-      - mv ~/qemu/bin/qemu-arm ~/qemu/bin/qemu-arm-static
       - ls -l ~/qemu/bin/
-      - ls -l /home/travis/qemu/bin/qemu-arm-static
       - wget https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-04-09/2019-04-08-raspbian-stretch-lite.zip
       - sudo env "PATH=$PATH" ~/packer/bin/packer build packer.json
       - ls -lh pimba.img

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ jobs:
     - stage: packer
       name: "enlarge raspbian disk image and activate ssh"
       script:
-      - ls -l ~/qemu/bin/
+      - sudo ln -s $HOME/qemu/bin/qemu-arm /usr/local/bin/qemu-arm-static
       - wget https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-04-09/2019-04-08-raspbian-stretch-lite.zip
       - sudo env "PATH=$PATH" ~/packer/bin/packer build packer.json
       - ls -lh pimba.img

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,6 @@ jobs:
     - stage: packer
       name: "enlarge raspbian disk image and activate ssh"
       script:
-      - sudo env "PATH=$PATH" which packer
-      - sudo env "PATH=$PATH" packer build packer.json
+      - sudo env "PATH=$PATH" echo $PATH
+      - sudo env "PATH=$PATH" ~/packer/bin/packer build packer.json
       - ls -lh pimba.img

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,6 @@ jobs:
       name: "enlarge raspbian disk image and activate ssh"
       script:
       - ln -s ~/qemu/bin/qemu-arm ~/qemu/bin/qemu-arm-static
-      - sudo env "PATH=$PATH" echo $PATH
+      - wget https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-04-09/2019-04-08-raspbian-stretch-lite.zip
       - sudo env "PATH=$PATH" ~/packer/bin/packer build packer.json
       - ls -lh pimba.img

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ before_script:
 - "echo build: $TRAVIS_BUILD_NUMBER"
 - bash bin/travis-qemu.sh
 - bash bin/travis-packer.sh
-- export PATH=$PATH:$HOME/qemu/bin:$HOME/packer/bin/
 
 jobs:
   include:
@@ -94,5 +93,5 @@ jobs:
       script:
       - sudo ln -s $HOME/qemu/bin/qemu-arm /usr/local/bin/qemu-arm-static
       - wget -nv https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-04-09/2019-04-08-raspbian-stretch-lite.zip
-      - sudo env "PATH=$PATH" ~/packer/bin/packer build packer.json
+      - sudo ~/packer/bin/packer build packer.json
       - ls -lh pimba.img

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ jobs:
     - stage: packer
       name: "enlarge raspbian disk image and activate ssh"
       script:
-      - ln -s ~/qemu/bin/qemu-arm ~/qemu/bin/qemu-arm-static
+      - mv ~/qemu/bin/qemu-arm ~/qemu/bin/qemu-arm-static
       - wget https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-04-09/2019-04-08-raspbian-stretch-lite.zip
       - sudo env "PATH=$PATH" ~/packer/bin/packer build packer.json
       - ls -lh pimba.img

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,6 @@ jobs:
       name: "enlarge raspbian disk image and activate ssh"
       script:
       - sudo ln -s $HOME/qemu/bin/qemu-arm /usr/local/bin/qemu-arm-static
-      - wget https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-04-09/2019-04-08-raspbian-stretch-lite.zip
+      - wget -qq https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-04-09/2019-04-08-raspbian-stretch-lite.zip
       - sudo env "PATH=$PATH" ~/packer/bin/packer build packer.json
       - ls -lh pimba.img

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,6 @@ jobs:
       name: "enlarge raspbian disk image and activate ssh"
       script:
       - sudo ln -s $HOME/qemu/bin/qemu-arm /usr/local/bin/qemu-arm-static
-      - wget -qq https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-04-09/2019-04-08-raspbian-stretch-lite.zip
+      - wget -nv https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-04-09/2019-04-08-raspbian-stretch-lite.zip
       - sudo env "PATH=$PATH" ~/packer/bin/packer build packer.json
       - ls -lh pimba.img

--- a/bin/travis-packer.sh
+++ b/bin/travis-packer.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+VERSION=${PACKER_VERSION:=1.4.2}
+
+if echo "${VERSION}" | cmp --silent ${HOME}/packer/.build -; then
+  echo "packer ${VERSION} up to date!"
+  exit 0
+fi
+
+echo "VERSION: ${VERSION}"
+
+cd ${HOME}
+rm -rf packer
+mkdir -p packer/{bin,build}
+
+# Checking for a tarball before downloading makes testing easier :-)
+test -f "packer_${VERSION}_linux_amd64.zip" || wget "https://releases.hashicorp.com/packer/${VERSION}/packer_${VERSION}_linux_amd64.zip"
+unzip "packer_${VERSION}_linux_amd64.zip" -d packer/bin
+
+cd ${HOME}/packer/build
+git clone https://github.com/solo-io/packer-builder-arm-image
+cd packer-builder-arm-image
+go mod download
+go build
+mv packer-builder-arm-image ${HOME}/packer/bin/packer-builder-arm-image
+
+
+echo "${VERSION}" > ${HOME}/packer/.build

--- a/bin/travis-packer.sh
+++ b/bin/travis-packer.sh
@@ -25,5 +25,4 @@ go mod download
 go build
 mv packer-builder-arm-image ${HOME}/packer/bin/packer-builder-arm-image
 
-
 echo "${VERSION}" > ${HOME}/packer/.build

--- a/bin/travis-qemu.sh
+++ b/bin/travis-qemu.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+VERSION=${QEMU_VERSION:=2.7.0}
+ARCHES=${QEMU_ARCHES:=arm aarch64 i386 x86_64}
+TARGETS=${QEMU_TARGETS:=$(echo $ARCHES | sed 's#$# #;s#\([^ ]*\) #\1-softmmu \1-linux-user #g')}
+
+if echo "$VERSION $TARGETS" | cmp --silent $HOME/qemu/.build -; then
+  echo "qemu $VERSION up to date!"
+  exit 0
+fi
+
+echo "VERSION: $VERSION"
+echo "TARGETS: $TARGETS"
+
+cd $HOME
+rm -rf qemu
+
+# Checking for a tarball before downloading makes testing easier :-)
+test -f "qemu-$VERSION.tar.bz2" || wget "http://wiki.qemu-project.org/download/qemu-$VERSION.tar.bz2"
+tar -xf "qemu-$VERSION.tar.bz2"
+cd "qemu-$VERSION"
+
+./configure \
+  --prefix="$HOME/qemu" \
+  --target-list="$TARGETS" \
+  --disable-docs \
+  --disable-sdl \
+  --disable-gtk \
+  --disable-gnutls \
+  --disable-gcrypt \
+  --disable-nettle \
+  --disable-curses \
+  --static
+
+make -j4
+make install
+
+echo "$VERSION $TARGETS" > $HOME/qemu/.build

--- a/bin/travis-qemu.sh
+++ b/bin/travis-qemu.sh
@@ -35,6 +35,7 @@ cd "qemu-$VERSION"
 
 make -j4
 make install
+ln -s $HOME/qemu/bin/qemu-arm $HOME/qemu/bin/qemu-arm-static
 
 # Install the good stuff from https://github.com/dhruvvyas90/qemu-rpi-kernel
 mkdir -p $HOME/qemu/rpi-kernel

--- a/bin/travis-qemu.sh
+++ b/bin/travis-qemu.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-VERSION=${QEMU_VERSION:=2.7.0}
-ARCHES=${QEMU_ARCHES:=arm aarch64 i386 x86_64}
+VERSION=${QEMU_VERSION:=4.0.0}
+ARCHES=${QEMU_ARCHES:=arm}
 TARGETS=${QEMU_TARGETS:=$(echo $ARCHES | sed 's#$# #;s#\([^ ]*\) #\1-softmmu \1-linux-user #g')}
 
 if echo "$VERSION $TARGETS" | cmp --silent $HOME/qemu/.build -; then
@@ -18,7 +18,7 @@ rm -rf qemu
 
 # Checking for a tarball before downloading makes testing easier :-)
 test -f "qemu-$VERSION.tar.bz2" || wget "http://wiki.qemu-project.org/download/qemu-$VERSION.tar.bz2"
-tar -xf "qemu-$VERSION.tar.bz2"
+tar -xjf "qemu-$VERSION.tar.bz2"
 cd "qemu-$VERSION"
 
 ./configure \
@@ -35,5 +35,10 @@ cd "qemu-$VERSION"
 
 make -j4
 make install
+
+# Install the good stuff from https://github.com/dhruvvyas90/qemu-rpi-kernel
+mkdir -p $HOME/qemu/rpi-kernel
+wget 'https://github.com/dhruvvyas90/qemu-rpi-kernel/blob/master/versatile-pb.dtb?raw=true' -O $HOME/qemu/rpi-kernel/versatile-pb.dtb
+wget 'https://github.com/dhruvvyas90/qemu-rpi-kernel/blob/master/kernel-qemu-4.14.79-stretch?raw=true' -O $HOME/qemu/rpi-kernel/kernel-qemu-4.14.79-stretch
 
 echo "$VERSION $TARGETS" > $HOME/qemu/.build

--- a/bin/travis-qemu.sh
+++ b/bin/travis-qemu.sh
@@ -35,7 +35,7 @@ cd "qemu-$VERSION"
 
 make -j4
 make install
-ln -s $HOME/qemu/bin/qemu-arm $HOME/qemu/bin/qemu-arm-static
+ln -s $HOME/qemu/bin/qemu-arm /usr/local/bin/qemu-arm-static
 
 # Install the good stuff from https://github.com/dhruvvyas90/qemu-rpi-kernel
 mkdir -p $HOME/qemu/rpi-kernel

--- a/bin/travis-qemu.sh
+++ b/bin/travis-qemu.sh
@@ -17,7 +17,7 @@ cd $HOME
 rm -rf qemu
 
 # Checking for a tarball before downloading makes testing easier :-)
-test -f "qemu-$VERSION.tar.bz2" || wget "http://wiki.qemu-project.org/download/qemu-$VERSION.tar.bz2"
+test -f "qemu-$VERSION.tar.bz2" || wget -nv "http://wiki.qemu-project.org/download/qemu-$VERSION.tar.bz2"
 tar -xjf "qemu-$VERSION.tar.bz2"
 cd "qemu-$VERSION"
 
@@ -38,7 +38,7 @@ make install
 
 # Install the good stuff from https://github.com/dhruvvyas90/qemu-rpi-kernel
 mkdir -p $HOME/qemu/rpi-kernel
-wget 'https://github.com/dhruvvyas90/qemu-rpi-kernel/blob/master/versatile-pb.dtb?raw=true' -O $HOME/qemu/rpi-kernel/versatile-pb.dtb
-wget 'https://github.com/dhruvvyas90/qemu-rpi-kernel/blob/master/kernel-qemu-4.14.79-stretch?raw=true' -O $HOME/qemu/rpi-kernel/kernel-qemu-4.14.79-stretch
+wget -nv 'https://github.com/dhruvvyas90/qemu-rpi-kernel/blob/master/versatile-pb.dtb?raw=true' -O $HOME/qemu/rpi-kernel/versatile-pb.dtb
+wget -nv 'https://github.com/dhruvvyas90/qemu-rpi-kernel/blob/master/kernel-qemu-4.14.79-stretch?raw=true' -O $HOME/qemu/rpi-kernel/kernel-qemu-4.14.79-stretch
 
 echo "$VERSION $TARGETS" > $HOME/qemu/.build

--- a/bin/travis-qemu.sh
+++ b/bin/travis-qemu.sh
@@ -35,7 +35,6 @@ cd "qemu-$VERSION"
 
 make -j4
 make install
-ln -s $HOME/qemu/bin/qemu-arm /usr/local/bin/qemu-arm-static
 
 # Install the good stuff from https://github.com/dhruvvyas90/qemu-rpi-kernel
 mkdir -p $HOME/qemu/rpi-kernel

--- a/librespot/Dockerfile
+++ b/librespot/Dockerfile
@@ -1,22 +1,32 @@
 FROM debian:stretch AS build
 
-RUN apt-get update && \
-    apt-get install -y curl git build-essential libasound2-dev pkg-config
+RUN dpkg --add-architecture armhf && \
+    apt-get update && \
+    apt-get install -y curl \
+        git build-essential \
+        libasound2-dev pkg-config \
+        crossbuild-essential-armhf libasound2-dev:armhf zlib1g-dev:armhf zlib1g-dev lib32z1
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin/:${PATH}"
-RUN rustup target add arm-unknown-linux-gnueabihf
+RUN rustup target add armv7-unknown-linux-gnueabihf
 
-RUN mkdir /.cargo && \
-    echo '[target.arm-unknown-linux-gnueabihf]\nlinker = "arm-linux-gnueabihf-gcc"' >> /.cargo/config
+RUN mkdir -p /.cargo && \
+    echo '[target.armv7-unknown-linux-gnueabihf]\nlinker = "arm-linux-gnueabihf-gcc"' >> /.cargo/config
 
+RUN cat /.cargo/config # DEBUG
 RUN mkdir /build
 ENV CARGO_TARGET_DIR /build
 ENV CARGO_HOME /build/cache
+ENV TARGET armv7-unknown-linux-gnueabihf
+
+# alsa-sys :(
+ENV  PKG_CONFIG_ALLOW_CROSS 1
+ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/pkgconfig
 
 RUN git clone https://github.com/librespot-org/librespot.git /src
 WORKDIR /src
-RUN cargo build --release --no-default-features --features "alsa-backend"
+RUN cargo build --release --no-default-features --features "alsa-backend" --target=armv7-unknown-linux-gnueabihf
 
 FROM debian:stretch
 RUN apt-get update && \
@@ -25,7 +35,7 @@ RUN apt-get update && \
 
 EXPOSE 4070
 RUN mkdir /librespot
-COPY --from=build /build/release/librespot /librespot/
+COPY --from=build /build/armv7-unknown-linux-gnueabihf/release/librespot /librespot/
 COPY librespot_avahi.service /librespot/librespot_avahi.service
 COPY start.sh /librespot/start.sh
 ENTRYPOINT ["/librespot/start.sh"]

--- a/packer.json
+++ b/packer.json
@@ -1,0 +1,22 @@
+{
+  "variables": {
+  },
+  "builders": [{
+    "type": "arm-image",
+    "iso_url" : "https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-04-09/2019-04-08-raspbian-stretch-lite.zip",
+    "iso_checksum_type" : "sha256",
+    "iso_checksum" : "03ec326d45c6eb6cef848cf9a1d6c7315a9410b49a276a6b28e67a40b11fdfcf",
+    "last_partition_extra_size" : 4294967296,
+    "output_directory" : "/tmp"
+  }],
+  "provisioners": [{
+    "type": "shell",
+    "inline": ["touch /boot/ssh && echo 'ssh activated'"]
+  }],
+  "post-processors": [{
+    "type": "shell-local",
+    "inline": [
+      "mv /tmp/image pimba.img"
+    ]
+  }]
+}

--- a/packer.json
+++ b/packer.json
@@ -3,7 +3,7 @@
   },
   "builders": [{
     "type": "arm-image",
-    "iso_url" : "https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-04-09/2019-04-08-raspbian-stretch-lite.zip",
+    "iso_url" : "2019-04-08-raspbian-stretch-lite.zip",
     "iso_checksum_type" : "sha256",
     "iso_checksum" : "03ec326d45c6eb6cef848cf9a1d6c7315a9410b49a276a6b28e67a40b11fdfcf",
     "last_partition_extra_size" : 4294967296,


### PR DESCRIPTION
- Fix librespot compilation: since using emulation is too slow and we hit the travis CI timeout, use cross-compilation instead (thanks https://github.com/RustAudio/cpal/issues/85#issue-109773627 for the PKG_CONFIG_PATH. That comment saved me from become insane)
- Add Packer step that extends raspbian stretch image by 4GB and activate SSH. This will be used at a later stage to configure the PiMBA image.