### PR TITLE
we only want to resize the fs if the option is set in settings, 

### DIFF
--- a/spec/localhost/system_spec.rb
+++ b/spec/localhost/system_spec.rb
@@ -10,4 +10,8 @@ context 'system' do
     it { should contain 'TZ=:/etc/localtime' }
   end
 
+  describe file('/etc/init.d/resize2fs_once') do
+    it { should_not exist }
+  end
+
 end

--- a/tasks/system.yaml
+++ b/tasks/system.yaml
@@ -7,3 +7,8 @@
   user:
     name: root
     password: musicbox
+
+- name: Make sure disk resize is not automatically set for first boot
+  file:
+    path: /etc/init.d/resize2fs_once
+    state: absent


### PR DESCRIPTION
so make sure it is not automatically set for first boot