### PR TITLE
Shrinking partitions seem to change the PARTUUID so it cannot be used…

### DIFF
--- a/files/etc/fstab
+++ b/files/etc/fstab
@@ -1,0 +1,5 @@
+proc            /proc           proc    defaults          0       0
+LABEL=boot      /boot           vfat    defaults          0       2
+LABEL=rootfs    /               ext4    defaults,noatime  0       1
+# a swapfile is not a swap partition, no line here
+#   use  dphys-swapfile swap[on|off]  for that

--- a/spec/localhost/system_spec.rb
+++ b/spec/localhost/system_spec.rb
@@ -14,4 +14,13 @@ context 'system' do
     it { should_not exist }
   end
 
+  describe file('/etc/fstab') do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 644 }
+    it { should contain 'LABEL=boot      /boot' }
+    it { should contain 'LABEL=rootfs    /' }
+  end
+
 end

--- a/tasks/system.yaml
+++ b/tasks/system.yaml
@@ -17,3 +17,11 @@
   file:
     path: /etc/init.d/resize2fs_once
     state: absent
+
+- name: Use LABELS in fstab instead of PARTUUID as shrink messes with it
+  copy:
+    src: files/etc/fstab
+    dest: /etc/fstab
+    mode: 0644
+    owner: root
+    group: root


### PR DESCRIPTION
… for the fstab. Using LABEL instead