### PR TITLE
Fix configuration conversion issue for "boolean-like" values

### DIFF
--- a/files/pimusicbox/startup.sh
+++ b/files/pimusicbox/startup.sh
@@ -12,7 +12,7 @@ echo "Initializing MusicBox..."
 echo "************************"
 
 # Load configuration
-eval "$(/usr/local/bin/ini2env -file "${CONFIG_FILE}" | grep '^INI__.*=".*"$')"
+eval "$(/usr/local/bin/ini2env -booleans -file "${CONFIG_FILE}" | grep '^INI__.*=".*"$')"
 
 # System setup
 # shellcheck source=files/pimusicbox/bin/system.sh

--- a/tasks/ini2env.yaml
+++ b/tasks/ini2env.yaml
@@ -1,6 +1,6 @@
 - name: Download ini2env and unpack it
   unarchive:
-    src: https://github.com/endemics/ini2env/releases/download/v0.1.0/ini2env_0.1.0_linux_armhf.tgz
+    src: https://github.com/endemics/ini2env/releases/download/v0.1.1/ini2env_0.1.1_linux_armhf.tgz
     remote_src: yes
     dest: /usr/local/bin
     owner: root


### PR DESCRIPTION
read_ini, that pimusicbox uses to process the configuration file,
allows for conversion of "boolean-like" values to either "1" (true)
or "0" (false).
For greater compatibility with existing configurations out there,
use version 0.1.1 of ini2env that has support for similar conversion
(with some functional changes though) through the -booleans flag.