### PR TITLE
Remove automatic resize on first boot (init_resize.sh) and reference …

### DIFF
--- a/files/boot/cmdline.txt
+++ b/files/boot/cmdline.txt
@@ -1,0 +1,1 @@
+dwc_otg.lpm_enable=0 console=serial0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait ipv6.disable=1

--- a/spec/localhost/system_spec.rb
+++ b/spec/localhost/system_spec.rb
@@ -23,4 +23,12 @@ context 'system' do
     it { should contain 'LABEL=rootfs    /' }
   end
 
+  describe file('/boot/cmdline.txt') do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should contain 'root=/dev/mmcblk0p2' }
+    it { should_not contain 'init=/usr/lib/raspi-config/init_resize.sh' }
+  end
+
 end

--- a/tasks/system.yaml
+++ b/tasks/system.yaml
@@ -25,3 +25,10 @@
     mode: 0644
     owner: root
     group: root
+
+- name: Remove resize from cmdline and use mmcblk0p2 for rootfs
+  copy:
+    src: files/boot/cmdline.txt
+    dest: /boot/cmdline.txt
+    owner: root
+    group: root


### PR DESCRIPTION
…to PARTUUID from cmdline, use mmcblk0p2 instead: fixes boot on real device