### PR TITLE
Update mechanism to disable user pi

### DIFF
--- a/goss/goss_system.yaml
+++ b/goss/goss_system.yaml
@@ -27,6 +27,12 @@ file:
     contents: [
       'root=/dev/mmcblk0p2'
     ]
+  /boot/userconf.txt:
+    exists: true
+    owner: root
+    group: root
+    filetype: file
+    contents: 'pi:*'
 command:
   'rootfs label':
     exit-status: 0

--- a/tasks/system.yaml
+++ b/tasks/system.yaml
@@ -15,9 +15,11 @@
     line: PermitRootLogin yes
 
 - name: Disable pi user
-  user:
-    name: pi
-    password: '*'
+  copy:
+    content: 'pi:*'
+    dest: /boot/userconf.txt
+    owner: root
+    group: root
 
 - name: Make sure disk resize is not automatically set for first boot
   file:


### PR DESCRIPTION
Following changes in raspberrypios bullseye, there is a new mechanism to set password to user pi

(see https://www.raspberrypi.com/news/raspberry-pi-bullseye-update-april-2022/) To avoid the pop-up asking for rename and still deactivate the user pi, creating a file /boot/userconf.txt with pi:* instead of changing the password directly.